### PR TITLE
Cache all ous

### DIFF
--- a/terraform/bootstrap/migrate_assignments_to_delegated_admin_model.py
+++ b/terraform/bootstrap/migrate_assignments_to_delegated_admin_model.py
@@ -426,6 +426,12 @@ def main(read_only, region):
             if account_with_ct_permission_set_provisioned == management_account_id:
                 is_management_account = True
 
+            if is_management_account:
+                print(
+                    "Skipping management account, as its permission sets do not need to be migrated to MEMBER-only versions"
+                )
+                continue
+
             # List assignments for the account/permission set
             account_assignments = sso_client.list_account_assignments(
                 AccountId=account_with_ct_permission_set_provisioned,

--- a/terraform/resolve_permission_sets_and_assignments.py
+++ b/terraform/resolve_permission_sets_and_assignments.py
@@ -578,7 +578,7 @@ def resolve_targets(
         # Account names, OUs, and ROOT
         else:
             new_accounts, updated_identifier_cache = list_accounts_in_identifier(
-                ou_identifier=string_target,
+                identifier=string_target,
                 all_accounts_map=all_accounts_map,
                 all_ous_map=all_ous_map,
                 boto_config=boto_config,
@@ -621,14 +621,13 @@ resource "aws_ssoadmin_account_assignment" "assignment_{account}{escaped_princip
 """
 
 
-def get_all_ous_map(org_client, parent_id, parent_name=""):
+def get_all_ous_map(org_client, parent_id, parent_name="", full_result={}):
     """
     Returns a map of all OUs in the Organization, with the OU name as the key and a list of
     objects containing OU IDs and OU full path names for each matching OU name.
 
     Recursively calls itself.
     """
-    full_result = {}
 
     paginator = org_client.get_paginator("list_children")
     iterator = paginator.paginate(
@@ -650,12 +649,11 @@ def get_all_ous_map(org_client, parent_id, parent_name=""):
                     "FullPath": f"{parent_name}/{ou_name}",
                 }
             )
-            full_result.extend(
-                get_all_ous_map(
-                    org_client=org_client,
-                    parent_id=ou["Id"],
-                    parent_name=ou_name,
-                )
+            full_result = get_all_ous_map(
+                org_client=org_client,
+                parent_id=ou["Id"],
+                parent_name=ou_name,
+                full_result=full_result,
             )
 
     return full_result

--- a/terraform/resolve_permission_sets_and_assignments.py
+++ b/terraform/resolve_permission_sets_and_assignments.py
@@ -391,6 +391,7 @@ def get_all_accounts_in_ou(
 
 def list_accounts_in_identifier(
     identifier: str,
+    # This account map is expected to include ONLY active accounts
     all_accounts_map: dict,
     all_ous_map: dict,
     boto_config: Config,

--- a/terraform/resolve_permission_sets_and_assignments_test.py
+++ b/terraform/resolve_permission_sets_and_assignments_test.py
@@ -481,7 +481,8 @@ resource "aws_ssoadmin_permissions_boundary_attachment" "TestPermissionSet_permi
         mock_boto3_client.return_value = mock_org_client
         accounts_map = {
             "active_account_in_ou_12345678": "111111111111",
-            "suspended_account_in_ou_12345678": "222222222222",
+            # commented out as this function now expects only active accounts
+            # "suspended_account_in_ou_12345678": "222222222222",
             "active_account_in_root": "333333333333",
             "active_account_in_root_2": "444444444444",
         }
@@ -522,16 +523,18 @@ resource "aws_ssoadmin_permissions_boundary_attachment" "TestPermissionSet_permi
 
         test_response_ou, _ = (
             resolve_permission_sets_and_assignments.list_accounts_in_identifier(
-                ou_identifier="ou-12345678",
+                identifier="ou-12345678",
                 all_accounts_map=accounts_map,
+                all_ous_map={},
                 boto_config=self.mock_boto_config,
                 identifier_cache={},
             )
         )
         test_response_root, _ = (
             resolve_permission_sets_and_assignments.list_accounts_in_identifier(
-                ou_identifier="r-12345",
+                identifier="r-12345",
                 all_accounts_map=accounts_map,
+                all_ous_map={},
                 boto_config=self.mock_boto_config,
                 identifier_cache={},
             )


### PR DESCRIPTION
This change will walk through all OUs at the start of the resolver script to create a map of all OU names to OU IDs.

This will allow for quick checks on whether a given free-text string is an OU, to help speed up processing.